### PR TITLE
nm_extract write to input path by default

### DIFF
--- a/src/NMExtract.cpp
+++ b/src/NMExtract.cpp
@@ -130,7 +130,7 @@ int main(int argc, char **argv)
   //Create output directory.
   fs::path outDstDir = outputDirectory;
 
-  if (! vm.count("output")) {
+  if ( (!vm.count("output")) || (outDstDir.empty()) )  {
     outDstDir = srcPath.parent_path();
     LOG(INFO) << "No output directory specified. Placing output in same directory as input.";
   }

--- a/src/NMExtract.cpp
+++ b/src/NMExtract.cpp
@@ -131,7 +131,8 @@ int main(int argc, char **argv)
   fs::path outDstDir = outputDirectory;
 
   if ( (!vm.count("output")) || (outDstDir.empty()) )  {
-    outDstDir = srcPath.parent_path();
+    
+    outDstDir = fs::canonical(srcPath).parent_path();
     LOG(INFO) << "No output directory specified. Placing output in same directory as input.";
   }
 


### PR DESCRIPTION
If no output path is specified `nm_extract` will now write to the same folder as the input.